### PR TITLE
Maxwell Cross replay on Read replica

### DIFF
--- a/config.properties.example
+++ b/config.properties.example
@@ -62,6 +62,10 @@ password=maxwell
 #replication_password=password
 #replication_port=3306
 
+# This will enable bootstrapping when replication host is on separate host than maxwell.
+# Helpfull when using read replica for streaming logs.
+#enable_cross_replay=false
+
 # This may be useful when using MaxScale's binlog mirroring host.
 # Specifies that Maxwell should capture schema from a different server than
 # it replicates from:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.zendesk</groupId>
   <artifactId>maxwell</artifactId>
-  <version>1.17.1</version>
+  <version>1.18.1</version>
   <packaging>jar</packaging>
 
   <name>maxwell</name>

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -92,6 +92,7 @@ public class MaxwellConfig extends AbstractConfig {
 	public int metricsDatadogPort;
 	public Long metricsDatadogInterval;
 	public boolean metricsJvm;
+	public boolean enableCrossReplay;
 
 	public MaxwellDiagnosticContext.Config diagnosticConfig;
 
@@ -126,6 +127,7 @@ public class MaxwellConfig extends AbstractConfig {
 	public String redisType;
 	public String javascriptFile;
 	public Scripting scripting;
+
 
 	public MaxwellConfig() { // argv is only null in tests
 		this.customProducerProperties = new Properties();
@@ -298,6 +300,7 @@ public class MaxwellConfig extends AbstractConfig {
 		parser.accepts( "http_diagnostic", "enable http diagnostic endpoint: true|false. default: false" ).withOptionalArg();
 		parser.accepts( "http_diagnostic_timeout", "the http diagnostic response timeout in ms when http_diagnostic=true. default: 10000" ).withRequiredArg();
 		parser.accepts( "metrics_jvm", "enable jvm metrics: true|false. default: false" ).withRequiredArg();
+		parser.accepts( "enable_cross_replay", "enable replay with separate streaming host: true|false. default: false" ).withRequiredArg();
 
 		parser.accepts( "__separator_11" );
 
@@ -458,6 +461,7 @@ public class MaxwellConfig extends AbstractConfig {
 		this.metricsDatadogInterval = fetchLongOption("metrics_datadog_interval", options, properties, 60L);
 
 		this.metricsJvm = fetchBooleanOption("metrics_jvm", options, properties, false);
+		this.enableCrossReplay = fetchBooleanOption("enable_cross_replay", options, properties, false);
 
 		this.diagnosticConfig = new MaxwellDiagnosticContext.Config();
 		this.diagnosticConfig.enable = fetchBooleanOption("http_diagnostic", options, properties, false);
@@ -717,7 +721,7 @@ public class MaxwellConfig extends AbstractConfig {
 		if (outputConfig.encryptionEnabled() && outputConfig.secretKey == null)
 			usage("--secret_key required");
 
-		if ( !maxwellMysql.sameServerAs(replicationMysql) && !this.bootstrapperType.equals("none") ) {
+		if ( !maxwellMysql.sameServerAs(replicationMysql) && !this.bootstrapperType.equals("none") && !this.enableCrossReplay) {
 			LOGGER.warn("disabling bootstrapping; not available when using a separate replication host.");
 			this.bootstrapperType = "none";
 		}

--- a/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
+++ b/src/main/java/com/zendesk/maxwell/bootstrap/SynchronousBootstrapper.java
@@ -94,7 +94,13 @@ public class SynchronousBootstrapper extends AbstractBootstrapper {
 	}
 
 	protected Connection getConnection() throws SQLException {
-		Connection conn = context.getReplicationConnection();
+                Connection conn = null;
+                if (context.getConfig().enableCrossReplay) {
+                        conn = context.getMaxwellConnection();
+	        } else {
+	                conn = context.getReplicationConnection();
+	        }
+
 		conn.setCatalog(context.getConfig().databaseName);
 		return conn;
 	}


### PR DESCRIPTION
#### What
Solution for https://github.com/zendesk/maxwell/issues/701

#### How
Uses maxwell connection instead of replication connection to update maxwell meta data based on configuration.

#### Usage
Point Maxwell Connection to RDS write instance and Replication Connection to its read replica. 
Set enable_cross_replay=true in config.properties